### PR TITLE
feat: enable return id after insert

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/CMySQL.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .upToNextMinor(from: "1.0.0"))
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "1.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Executing a `SELECT LAST_INSERT_ID()` statement if Insert Query return id flag is set, passing the completion into the next query.