### PR TITLE
Finished conversion to Swift 4.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MySQL plugin for Swift-Kuery framework
 [MySQL](https://dev.mysql.com/) plugin for the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) framework. It enables you to use Swift-Kuery to manipulate data in a MySQL database.
 
 ## Swift version
-The latest version of SwiftKueryMySQL requires **Swift 4.0**. You can download this version of the Swift binaries by following this [link](https://swift.org/download/). Compatibility with other Swift versions is not guaranteed.
+The latest version of SwiftKueryMySQL requires **Swift 4.0.3**. You can download this version of the Swift binaries by following this [link](https://swift.org/download/). Compatibility with other Swift versions is not guaranteed.
 
 ### Install MySQL
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ MySQL plugin for Swift-Kuery framework
 [MySQL](https://dev.mysql.com/) plugin for the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) framework. It enables you to use Swift-Kuery to manipulate data in a MySQL database.
 
 ## Swift version
-The latest version of SwiftKueryMySQL requires **Swift 4.0.3**. You can download this version of the Swift binaries by following this [link](https://swift.org/download/). Compatibility with other Swift versions is not guaranteed.
+The latest version of SwiftKueryMySQL requires **Swift 4.0**. You can download this version of the Swift binaries by following this [link](https://swift.org/download/). Compatibility with other Swift versions is not guaranteed.
 
 ### Install MySQL
 

--- a/Sources/SwiftKueryMySQL/MySQLPreparedStatement.swift
+++ b/Sources/SwiftKueryMySQL/MySQLPreparedStatement.swift
@@ -230,7 +230,7 @@ public class MySQLPreparedStatement: PreparedStatement {
             initialize(string: formattedDate, &bind)
         case let byteArray as [UInt8]:
             let typedBuffer = allocate(type: UInt8.self, capacity: byteArray.count, bind: &bind)
-                typedBuffer.initialize(from: byteArray)
+            typedBuffer.initialize(from: byteArray, count: byteArray.count)
         case let data as Data:
             let typedBuffer = allocate(type: UInt8.self, capacity: data.count, bind: &bind)
             data.copyBytes(to: typedBuffer, count: data.count)
@@ -308,9 +308,9 @@ public class MySQLPreparedStatement: PreparedStatement {
     }
 
     private func initialize(string: String, _ bind: inout MYSQL_BIND) {
-        let utf8 = string.utf8
+        let utf8 = Array(string.utf8)
         let typedBuffer = allocate(type: UInt8.self, capacity: utf8.count, bind: &bind)
-            typedBuffer.initialize(from: utf8)
+        typedBuffer.initialize(from: utf8, count: utf8.count)
     }
 
     private func getType(parameter: Any) -> enum_field_types {


### PR DESCRIPTION
Warnings were still present regarding buffers (methods had been deprecated). These warnings have been resolved, and now Swift 4 syntax is used.

I have already signed a CLA.