### PR TITLE
fix: Return id AS column name

### DIFF
--- a/Sources/SwiftKueryMySQL/MySQLPreparedStatement.swift
+++ b/Sources/SwiftKueryMySQL/MySQLPreparedStatement.swift
@@ -108,6 +108,9 @@ public class MySQLPreparedStatement: PreparedStatement {
                   throw QueryError.syntaxError("Could not retrieve ID Column in order to return the ID value")
                 }
 
+                // Note: This will return the last auto incremented value in the
+                // table. It is not guaranteed that it will return the primary
+                // key value if multiple columns are auto incremented
                 try MySQLPreparedStatement("SELECT LAST_INSERT_ID() AS \(idColumn.name)", mysql: self.mysql).execute(onCompletion: onCompletion)
                 return
               }

--- a/Sources/SwiftKueryMySQL/MySQLPreparedStatement.swift
+++ b/Sources/SwiftKueryMySQL/MySQLPreparedStatement.swift
@@ -104,7 +104,11 @@ public class MySQLPreparedStatement: PreparedStatement {
 
             do {
               if query != nil, let insertQuery = query as? Insert, insertQuery.returnID {
-                try MySQLPreparedStatement("SELECT LAST_INSERT_ID() AS id",mysql: self.mysql).execute(onCompletion: onCompletion)
+                guard let idColumn = insertQuery.table.columns.first(where: {$0.isPrimaryKey && $0.autoIncrement}) else {
+                  throw QueryError.syntaxError("Could not retrieve ID Column in order to return the ID value")
+                }
+
+                try MySQLPreparedStatement("SELECT LAST_INSERT_ID() AS \(idColumn.name)", mysql: self.mysql).execute(onCompletion: onCompletion)
                 return
               }
             } catch {


### PR DESCRIPTION
Returns the last auto incrementing value after an insert. This is not guaranteed to be the primary key of the table.