### PR TITLE
Update to support mysql 8

### DIFF
--- a/.swift-build-linux
+++ b/.swift-build-linux
@@ -1,0 +1,1 @@
+swift build -Xcc -I/usr/include/mysql

--- a/.swift-build-macOS
+++ b/.swift-build-macOS
@@ -1,1 +1,1 @@
-swift build -Xlinker -L/usr/local/lib
+swift build -Xlinker -L/usr/local/lib -Xcc -I/usr/local/include/mysql

--- a/.swift-xcodeproj
+++ b/.swift-xcodeproj
@@ -1,1 +1,1 @@
-swift package -Xlinker -L/usr/local/lib generate-xcodeproj 
+swift package -Xlinker -L/usr/local/lib generate-xcodeproj -xcconfig-overrides Config.xcconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      services: docker
+      env:
+        - DOCKER_IMAGE=ubuntu:17.10 SWIFT_SNAPSHOT=https://swift.org/builds/swift-4.0-branch/ubuntu1610/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-12-04-a/swift-4.0-DEVELOPMENT-SNAPSHOT-2017-12-04-a-ubuntu16.10.tar.gz
     - os: osx
       osx_image: xcode9.2
       sudo: required
-
-services:
-  - mysql
 
 script:
   - ./build.sh

--- a/Config.xcconfig
+++ b/Config.xcconfig
@@ -1,0 +1,13 @@
+//
+//  Config.xcconfig
+//  SwiftKueryMySQL
+//
+//  Created by Matthew Kilner on 02/07/2018.
+//
+
+//:configuration = Debug
+HEADER_SEARCH_PATHS = /usr/local/include/mysql
+
+//:configuration = Release
+HEADER_SEARCH_PATHS = /usr/local/include/mysql
+

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Other install options: https://dev.mysql.com/doc/refman/5.7/en/osx-installation.
 On macOS, add `-Xlinker -L/usr/local/lib` to swift commands to point the linker to the MySQL library location.
 For example,
 ```
-swift build -Xlinker -L/usr/local/lib
-swift test -Xlinker -L/usr/local/lib
-swift package -Xlinker -L/usr/local/lib generate-xcodeproj
+swift build -Xlinker -L/usr/local/lib -Xcc -I/usr/local/bin
+swift test -Xlinker -L/usr/local/lib -Xcc -I/usr/local/bin
+swift package -Xlinker -L/usr/local/lib generate-xcodeproj -xcconfig-overrides Config.xcconfig
 ```
 
 #### Linux

--- a/Sources/SwiftKueryMySQL/MySQLPreparedStatement.swift
+++ b/Sources/SwiftKueryMySQL/MySQLPreparedStatement.swift
@@ -171,7 +171,7 @@ public class MySQLPreparedStatement: PreparedStatement {
             }
         }
 
-        guard mysql_stmt_bind_param(statement, bindPtr) == 0 else {
+        guard mysql_stmt_bind_param(statement, bindPtr) == false else {
             throw QueryError.databaseError(MySQLConnection.getError(statement!))
         }
     }
@@ -200,18 +200,18 @@ public class MySQLPreparedStatement: PreparedStatement {
 
     private func setBind(_ bind: inout MYSQL_BIND, _ parameter: Any?, _ column: Column?) {
         if bind.is_null == nil {
-            bind.is_null = UnsafeMutablePointer<Int8>.allocate(capacity: 1)
+            bind.is_null = UnsafeMutablePointer<Bool>.allocate(capacity: 1)
         }
 
         guard let parameter = parameter else {
             bind.buffer_type = MYSQL_TYPE_NULL
-            bind.is_null.initialize(to: 1)
+            bind.is_null.initialize(to: true)
             return
         }
 
         bind.buffer_type = getType(parameter: parameter)
-        bind.is_null.initialize(to: 0)
-        bind.is_unsigned = 0
+        bind.is_null.initialize(to: false)
+        bind.is_unsigned = false
 
         switch parameter {
         case let string as String:
@@ -254,22 +254,22 @@ public class MySQLPreparedStatement: PreparedStatement {
             initialize(int, &bind)
         case let uint as UInt:
             initialize(uint, &bind)
-            bind.is_unsigned = 1
+            bind.is_unsigned = true
         case let uint as UInt8:
             initialize(uint, &bind)
-            bind.is_unsigned = 1
+            bind.is_unsigned = true
         case let uint as UInt16:
             initialize(uint, &bind)
-            bind.is_unsigned = 1
+            bind.is_unsigned = true
         case let uint as UInt32:
             initialize(uint, &bind)
-            bind.is_unsigned = 1
+            bind.is_unsigned = true
         case let uint as UInt64:
             initialize(uint, &bind)
-            bind.is_unsigned = 1
+            bind.is_unsigned = true
         case let unicodeScalar as UnicodeScalar:
             initialize(unicodeScalar, &bind)
-            bind.is_unsigned = 1
+            bind.is_unsigned = true
         default:
             print("WARNING: Unhandled parameter \(parameter) (type: \(type(of: parameter))). Will attempt to convert it to a String")
             initialize(string: String(describing: parameter), &bind)

--- a/Sources/SwiftKueryMySQL/MySQLResultFetcher.swift
+++ b/Sources/SwiftKueryMySQL/MySQLResultFetcher.swift
@@ -56,7 +56,7 @@ public class MySQLResultFetcher: ResultFetcher {
             bindPtr[i] = binds[i]
         }
 
-        guard mysql_stmt_bind_result(preparedStatement.statement, bindPtr) == 0 else {
+        guard mysql_stmt_bind_result(preparedStatement.statement, bindPtr) == false else {
             throw MySQLResultFetcher.initError(preparedStatement, bindPtr: bindPtr, binds: binds)
         }
 
@@ -151,12 +151,12 @@ public class MySQLResultFetcher: ResultFetcher {
         var bind = MYSQL_BIND()
         bind.buffer_type = field.type
         bind.buffer_length = UInt(size)
-        bind.is_unsigned = 0
+        bind.is_unsigned = false
 
         bind.buffer = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)
         bind.length = UnsafeMutablePointer<UInt>.allocate(capacity: 1)
-        bind.is_null = UnsafeMutablePointer<my_bool>.allocate(capacity: 1)
-        bind.error = UnsafeMutablePointer<my_bool>.allocate(capacity: 1)
+        bind.is_null = UnsafeMutablePointer<Bool>.allocate(capacity: 1)
+        bind.error = UnsafeMutablePointer<Bool>.allocate(capacity: 1)
 
         return bind
     }
@@ -205,7 +205,7 @@ public class MySQLResultFetcher: ResultFetcher {
                 continue
             }
 
-            guard bind.is_null.pointee == 0 else {
+            guard bind.is_null.pointee == false else {
                 row.append(nil)
                 continue
             }

--- a/build.sh
+++ b/build.sh
@@ -2,19 +2,32 @@
 
 set -o verbose
 
-
-if [[ $TRAVIS_OS_NAME == "osx" ]]; then
-    mysql --version || { brew update && brew install mysql && mysql.server start && mysql --version; }
+if [ -n "${DOCKER_IMAGE}" ]; then
+    docker pull ${DOCKER_IMAGE}
+    docker run --env SWIFT_SNAPSHOT -v ${TRAVIS_BUILD_DIR}:${TRAVIS_BUILD_DIR} ${DOCKER_IMAGE} /bin/bash -c "apt-get update && apt-get install -y apt-utils debconf-utils dialog git sudo lsb-release wget libxml2 && cd $TRAVIS_BUILD_DIR && ./build.sh"
 else
-    export DEBIAN_FRONTEND="noninteractive"
-    mysql --version || { apt-get update && apt-get install -y mysql-server libmysqlclient-dev && service mysql start && mysql --version; }
+    if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+        mysql --version || { brew update && brew install mysql && mysql.server start && mysql --version; }
+    else
+        export DEBIAN_FRONTEND=noninteractive
+        cd /tmp
+        wget https://dev.mysql.com/get/mysql-apt-config_0.8.10-1_all.deb
+        cd -
+        echo mysql-apt-config mysql-apt-config/select-server select mysql-8.0 | debconf-set-selections
+        dpkg -i /tmp/mysql-apt-config_0.8.10-1_all.deb
+        echo mysql-community-server mysql-community-server/root-pass password | debconf-set-selections
+        apt-get update -y
+        apt-get install -q -y mysql-server
+        apt-get install -y libmysqlclient-dev
+        service mysql start
+        mysql --version
+    fi
+
+    mysql_upgrade -uroot || echo "No need to upgrade"
+    mysql -uroot -e "CREATE USER 'swift'@'localhost' IDENTIFIED BY 'kuery';"
+    mysql -uroot -e "CREATE DATABASE IF NOT EXISTS test;"
+    mysql -uroot -e "GRANT ALL ON test.* TO 'swift'@'localhost';"
+
+    git clone -b install_from_url --single-branch https://github.com/IBM-Swift/Package-Builder.git
+    ./Package-Builder/build-package.sh -projectDir $(pwd)
 fi
-
-mysql_upgrade -uroot || echo "No need to upgrade"
-mysql -uroot -e "CREATE USER 'swift'@'localhost' IDENTIFIED BY 'kuery';"
-mysql -uroot -e "CREATE DATABASE IF NOT EXISTS test;"
-mysql -uroot -e "GRANT ALL ON test.* TO 'swift'@'localhost';"
-
-git clone https://github.com/IBM-Swift/Package-Builder.git
-./Package-Builder/build-package.sh -projectDir $(pwd)
-


### PR DESCRIPTION
This PR updates the plugin to support mysql version 8 and updates the travis configuration as necessary.

We can update to point at the head of package builder once the per-requisite changes are merged.