### PR TITLE
 Build column description in the plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/IBM-Swift/CMySQL.git", .upToNextMinor(from: "0.1.0")),
-        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "2.0.0")
+        //.package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", from: "2.0.0")
+        .package(url: "https://github.com/IBM-Swift/Swift-Kuery.git", .branch("issue_column_attributes") ),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/SwiftKueryMySQL/MySQLConnection.swift
+++ b/Sources/SwiftKueryMySQL/MySQLConnection.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2017
+ Copyright IBM Corporation 2017, 2018
  
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/Sources/SwiftKueryMySQL/MySQLConnection.swift
+++ b/Sources/SwiftKueryMySQL/MySQLConnection.swift
@@ -443,7 +443,7 @@ class MySQLColumnBuilder: ColumnCreator {
             result += typeString
         }
 
-        if column.isPrimaryKey && !column.autoIncrement {
+        if column.isPrimaryKey {
             result += " PRIMARY KEY"
         }
         if column.isNotNullable {

--- a/Sources/SwiftKueryMySQL/MySQLConnection.swift
+++ b/Sources/SwiftKueryMySQL/MySQLConnection.swift
@@ -59,7 +59,7 @@ public class MySQLConnection: Connection {
     /// The `QueryBuilder` with MySQL specific substitutions.
     public let queryBuilder: QueryBuilder = {
         let queryBuilder = QueryBuilder(addNumbersToParameters: false,
-                                        anyOnSubquerySupported: true,
+                                        anyOnSubquerySupported: true, columnBuilder: MySQLColumnBuilder(),
                                         dropIndexRequiresOnTableName: true,
                                         dateFormatter: MySQLConnection.queryBuilderDateFormatter)
 
@@ -420,3 +420,84 @@ public class MySQLConnection: Connection {
         return "ERROR \(mysql_stmt_errno(statement)): " + String(cString: mysql_stmt_error(statement))
     }
 }
+
+class MySQLColumnBuilder: ColumnCreator {
+    func buildColumn(for column: Column, using queryBuilder: QueryBuilder) -> String? {
+        guard let type = column.type else {
+            return nil
+        }
+
+        var result = column.name
+        let identifierQuoteCharacter = queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.identifierQuoteCharacter.rawValue]
+        if !result.hasPrefix(identifierQuoteCharacter) {
+            result = identifierQuoteCharacter + result + identifierQuoteCharacter + " "
+        }
+
+        var typeString = type.create(queryBuilder: queryBuilder)
+        if let length = column.length {
+            typeString += "(\(length))"
+        }
+        if column.autoIncrement && typeCanBeAutoIncrement(typeString) {
+            result += typeString + " AUTO_INCREMENT"
+        } else {
+            result += typeString
+        }
+
+        if column.isPrimaryKey && !column.autoIncrement {
+            result += " PRIMARY KEY"
+        }
+        if column.isNotNullable {
+            result += " NOT NULL"
+        }
+        if column.isUnique {
+            result += " UNIQUE"
+        }
+        if let defaultValue = column.defaultValue {
+            var packedType: String
+            do {
+                packedType = try packType(defaultValue, queryBuilder: queryBuilder)
+            } catch {
+                return nil
+            }
+            result += " DEFAULT " + packedType
+        }
+        if let checkExpression = column.checkExpression {
+            result += checkExpression.contains(column.name) ? " CHECK (" + checkExpression.replacingOccurrences(of: column.name, with: "\"\(column.name)\"") + ")" : " CHECK (" + checkExpression + ")"
+        }
+        if let collate = column.collate {
+            result += " COLLATE \"" + collate + "\""
+        }
+        return result
+    }
+
+    func packType(_ item: Any, queryBuilder: QueryBuilder) throws -> String {
+        switch item {
+        case let val as String:
+            return "'\(val)'"
+        case let val as Bool:
+            return val ? queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.booleanTrue.rawValue]
+                : queryBuilder.substitutions[QueryBuilder.QuerySubstitutionNames.booleanFalse.rawValue]
+        case let val as Parameter:
+            return try val.build(queryBuilder: queryBuilder)
+        case let value as Date:
+            if let dateFormatter = queryBuilder.dateFormatter {
+                return dateFormatter.string(from: value)
+            }
+            return "'\(String(describing: value))'"
+        default:
+            return String(describing: item)
+        }
+    }
+
+    func typeCanBeAutoIncrement(_ type: String) -> Bool {
+        switch type.lowercased() {
+        case  "integer", "smallint", "tinyint", "mediumint", "bigint":
+            return true
+        case "float", "double":
+            return true
+        default:
+            return false
+        }
+    }
+}
+

--- a/Sources/SwiftKueryMySQL/MySQLConnection.swift
+++ b/Sources/SwiftKueryMySQL/MySQLConnection.swift
@@ -490,7 +490,7 @@ class MySQLColumnBuilder: ColumnCreator {
     }
 
     func typeCanBeAutoIncrement(_ type: String) -> Bool {
-        switch type.lowercased() {
+        switch type {
         case  "integer", "smallint", "tinyint", "mediumint", "bigint":
             return true
         case "float", "double":

--- a/Tests/SwiftKueryMySQLTests/TestSchema.swift
+++ b/Tests/SwiftKueryMySQLTests/TestSchema.swift
@@ -34,6 +34,7 @@ class TestSchema: MySQLTest {
             ("testForeignKeys", testForeignKeys),
             ("testPrimaryKeys", testPrimaryKeys),
             ("testTypes", testTypes),
+            ("testAutoIncrement", testAutoIncrement),
         ]
     }
 
@@ -334,4 +335,83 @@ class TestSchema: MySQLTest {
             }
         })
     }
+
+    class AutoIncrement1: Table {
+        let a = Column("a", String.self)
+        let b = Column("b", Int32.self, autoIncrement: true, primaryKey: true)
+
+        let tableName = "AutoIncrement1" + tableNameSuffix
+    }
+
+    class AutoIncrement2: Table {
+        let a = Column("a", String.self, primaryKey: true)
+        let b = Column("b", Int32.self, autoIncrement: true)
+
+        let tableName = "AutoIncrement2" + tableNameSuffix
+    }
+
+    class AutoIncrement3: Table {
+        let a = Column("a", String.self)
+        let b = Column("b", String.self, autoIncrement: true, primaryKey: true)
+
+        let tableName = "AutoIncrement3" + tableNameSuffix
+    }
+
+    func testAutoIncrement() {
+        performTest(asyncTasks: { connection in
+            let t1 = AutoIncrement1()
+            let t2 = AutoIncrement2()
+            let t3 = AutoIncrement3()
+
+            cleanUp(table: t1.tableName, connection: connection) { _ in }
+            cleanUp(table: t2.tableName, connection: connection) { _ in }
+            cleanUp(table: t3.tableName, connection: connection) { _ in }
+
+            t1.create(connection: connection) { result in
+                XCTAssertEqual(result.success, true, "CREATE TABLE failed for \(t1.tableName)")
+            }
+
+            t2.create(connection: connection) { result in
+                XCTAssertEqual(result.success, false, "CREATE TABLE non primary key auto increment column didn't fail")
+            }
+
+            t3.create(connection: connection) { result in
+                XCTAssertEqual(result.success, false, "CREATE TABLE non integer auto increment column didn't fail")
+            }
+        })
+    }
+
+/*    func testAutoIncrement() {
+        let t1 = AutoIncrement1()
+        let t2 = AutoIncrement2()
+        let t3 = AutoIncrement3()
+
+        let pool = CommonUtils.sharedInstance.getConnectionPool()
+        performTest(asyncTasks: { expectation in
+
+            guard let connection = pool.getConnection() else {
+                XCTFail("Failed to get connection")
+                return
+            }
+            cleanUp(table: t1.tableName, connection: connection) { result in
+                cleanUp(table: t2.tableName, connection: connection) { result in
+                    cleanUp(table: t3.tableName, connection: connection) { result in
+
+                        t1.create(connection: connection) { result in
+                            XCTAssertEqual(result.success, true, "CREATE TABLE failed for \(t1.tableName)")
+
+                            t2.create(connection: connection) { result in
+                                XCTAssertEqual(result.success, false, "CREATE TABLE non primary key auto increment column didn't fail")
+
+                                t3.create(connection: connection) { result in
+                                    XCTAssertEqual(result.success, false, "CREATE TABLE non integer auto increment column didn't fail")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            expectation.fulfill()
+        })
+    }*/
 }

--- a/Tests/SwiftKueryMySQLTests/TestSchema.swift
+++ b/Tests/SwiftKueryMySQLTests/TestSchema.swift
@@ -1,5 +1,5 @@
 /**
- Copyright IBM Corporation 2017
+ Copyright IBM Corporation 2017, 2018
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR updates the plugin to conform to the new QueryBuilder requirements and adds the logic to build a string representation of a column for the plugin.

I have include two implementations of the test, the non-commented version will need replacing with the commented version when we merge the async changes.