### PR TITLE
Do not rely on system sevices to launch mysql

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -31,7 +31,8 @@ else
             sudo -E apt-get install -y pkg-config
             sudo -E apt-get install -q -y mysql-server
             sudo -E apt-get install -y libmysqlclient-dev
-            sudo -E service mysql start
+            /usr/bin/mysqld_safe --user=mysql &
+            sleep 5
             mysql --version
         fi
     fi


### PR DESCRIPTION
This PR updates the build script to launch mysql explicitly rather than relying on system services which may not be present within a docker image.