### PR TITLE
Build against Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,12 @@ matrix:
       env:
         - DOCKER_IMAGE=ubuntu:16.04 MYSQL_VER=5
       sudo: required
+    - os: linux
+      dist: trusty
+      services: docker
+      env:
+        - DOCKER_IMAGE=ubuntu:16.04 MYSQL_VER=5 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
+      sudo: required
     # Currently mysql 8 does not install cleanly on ubuntu 16.04
     #- os: linux
     #  dist: trusty
@@ -111,6 +117,11 @@ matrix:
       sudo: required
       env:
         - MYSQL_VER=8
+    - os: osx
+      osx_image: xcode10
+      sudo: required
+      env:
+        - MYSQL_VER=8 SWIFT_SNAPSHOT=$SWIFT_DEVELOPMENT_SNAPSHOT
 
 script:
   - ./build.sh

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .systemLibrary(
             name: "CMySQL",
-            pkgConfig: "mysqlclient"
+            pkgConfig: "mysqlclient",
+            providers: [
+                .brew(["mysql"]),
+                .apt(["libmysqlclient-dev"])
+            ]
         ),
         .target(
             name: "SwiftKueryMySQL",


### PR DESCRIPTION
Adds testing with a Swift 5 development snapshot. The snapshot is defined in Travis as `SWIFT_DEVELOPMENT_SNAPSHOT` consistently across the IBM-Swift repos, to enable us to automate updating the version.

Also adds missing `providers` to the Swift 4.2 system library target.