### PR TITLE
Remove reference to Threadsafe connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,11 @@ Successfully inserted age: 3
 Successfully inserted age: 4
 Successfully inserted age: 5
 ```
-This is because the single connection pool only allows a single thread at a time to obtain the connection. If you edit the maximum capacity of the thread pool the ordering of inserts is more random as they occur concurrently on different connections:
+This is because the connection pool only allows that connection to be obtained by a single task. Because the connection pool is now empty, additional tasks are queued for later execution. As each task completes, the single connection is returned to the pool, and the next task is then invoked.
+
+In the example above, a DispatchGroup is used to pause the main thread until all of the tasks complete. This is necessary because the call to connectionPool.getConnection() returns immediately - the task is invoked later, once a connection is available.
+
+If you increase the capacity of the thread pool, then the order of inserts will be unpredictable, as they are able to execute concurrently on different connections:
 ```
 Successfully inserted age: 0
 Successfully inserted age: 1

--- a/README.md
+++ b/README.md
@@ -127,6 +127,23 @@ connection.connect() { result in
 }
 ```
 
+MySQLConnections should not be used to execute concurrent operations and therefore should not be shared across threads without proper synchronisation in place. It is recommended to use a connection pool containing a single connection if you wish to share a connection between multiple threads:
+
+```swift
+let poolOptions = ConnectionPoolOptions(initialCapacity: 1, maxCapacity: 1)
+pool = MySQLConnection.createPool(host: host, user: username, password: password, database: database, port: port, characterSet: characterSet, connectionTimeout: 10000, poolOptions: poolOptions)
+
+pool.getConnection() { connection, error in
+    guard let connection = connection else {
+        //Handle error
+        return
+    }
+    // Use connection
+}
+```
+
+The connection pool will ensure your connection is not used concurrently.
+
 View the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) documentation for detailed information on using the Swift-Kuery framework.
 
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ connection.connect() { result in
 }
 ```
 
-MySQLConnections should not be used to execute concurrent operations and therefore should not be shared across threads without proper synchronisation in place. It is recommended to use a connection pool if you wish to share connections between multiple threads as the connection pool will ensure your connection is not used concurrently.The example below creates a `ConnectionPool` containing a single connection and uses it to perform an insert on multiple threads:
+MySQLConnections should not be used to execute concurrent operations and therefore should not be shared across threads without proper synchronisation in place. It is recommended to use a connection pool if you wish to share connections between multiple threads as the connection pool will ensure your connection is not used concurrently.  
+
+The example below creates a `ConnectionPool` containing a single connection and uses it to perform an insert on multiple threads:
 
 ```swift
 var connectionPoolOptions = ConnectionPoolOptions.init(initialCapacity: 1, maxCapacity: 1)
@@ -139,23 +141,13 @@ for age in 0 ... 5 {
     insertGroup.enter()
     connectionPool.getConnection() { connection, error in
         guard let connection = connection else {
-            guard let error = error else {
-                print("Unable to get connection: Unknown error")
-                return insertGroup.leave()
-            }
-            print ("Unable to get connection: \(error.localizedDescription)")
-            return insertGroup.leave()
+            // Error Handling and return
         }
         connection.execute(query: insertQuery, parameters: [age]) { result in
             guard result.success else {
-                guard let error = result.asError else {
-                    print("Unable to insert age: \(age): Unknown error")
-                    return insertGroup.leave()
-                }
-                print("Unable to age: \(age): \(error.localizedDescription)")
-                return insertGroup.leave()
+                // Error handling and return
             }
-            print("Succesfully inserted age: \(age)")
+            print("Successfully inserted age: \(age)")
             return insertGroup.leave()
         }
     }
@@ -164,21 +156,21 @@ insertGroup.wait()
 ```
 When executing this example code you see output similar to:
 ```
-Succesfully inserted age: 0
-Succesfully inserted age: 1
-Succesfully inserted age: 2
-Succesfully inserted age: 3
-Succesfully inserted age: 4
-Succesfully inserted age: 5
+Successfully inserted age: 0
+Successfully inserted age: 1
+Successfully inserted age: 2
+Successfully inserted age: 3
+Successfully inserted age: 4
+Successfully inserted age: 5
 ```
 This is because the single connection pool only allows a single thread at a time to obtain the connection. If you edit the maximum capacity of the thread pool the ordering of inserts is more random as they occur concurrently on different connections:
 ```
-Succesfully inserted age: 0
-Succesfully inserted age: 1
-Succesfully inserted age: 3
-Succesfully inserted age: 2
-Succesfully inserted age: 5
-Succesfully inserted age: 4
+Successfully inserted age: 0
+Successfully inserted age: 1
+Successfully inserted age: 3
+Successfully inserted age: 2
+Successfully inserted age: 5
+Successfully inserted age: 4
 ```
 
 View the [Swift-Kuery](https://github.com/IBM-Swift/Swift-Kuery) documentation for detailed information on using the Swift-Kuery framework.

--- a/Sources/SwiftKueryMySQL/MySQLConnection.swift
+++ b/Sources/SwiftKueryMySQL/MySQLConnection.swift
@@ -22,7 +22,7 @@ import CMySQL
 
 /// An implementation of `SwiftKuery.Connection` protocol for MySQL.
 /// Connections should not be used to execute concurrent operations.
-/// To share connections across threads it is recommended to use a Connection pool with a max capacity of 1.
+/// To share connections across threads it is recommended to use a Connection pool.
 public class MySQLConnection: Connection {
 
     private static let initOnce: () = {

--- a/Sources/SwiftKueryMySQL/MySQLConnection.swift
+++ b/Sources/SwiftKueryMySQL/MySQLConnection.swift
@@ -22,7 +22,7 @@ import CMySQL
 
 /// An implementation of `SwiftKuery.Connection` protocol for MySQL.
 /// Connections should not be used to execute concurrent operations.
-/// To share connections across threads it is recommended to use a Connection pool.
+/// To safely share connections across threads, consider using a Connection pool.
 public class MySQLConnection: Connection {
 
     private static let initOnce: () = {

--- a/Sources/SwiftKueryMySQL/MySQLConnection.swift
+++ b/Sources/SwiftKueryMySQL/MySQLConnection.swift
@@ -21,8 +21,8 @@ import Dispatch
 import CMySQL
 
 /// An implementation of `SwiftKuery.Connection` protocol for MySQL.
-/// Instances of MySQLConnection are NOT thread-safe and should not be shared between threads.
-/// Use `MySQLThreadSafeConnection` to share connection instances between multiple threads.
+/// Connections should not be used to execute concurrent operations.
+/// To share connections across threads it is recommended to use a Connection pool with a max capacity of 1.
 public class MySQLConnection: Connection {
 
     private static let initOnce: () = {


### PR DESCRIPTION
This PR removes a comment referencing the thread safe connection class that was removed in SwiftKueryMySQL 3.

It also updates the Readme with advice on how to use connections in a thread safe manner and example code.